### PR TITLE
Use /usr/lib/udev/rules.d/ instead of /etc/udev/rules.d/

### DIFF
--- a/LINUX/Makefile
+++ b/LINUX/Makefile
@@ -98,7 +98,7 @@ install-all: install install-plugin
 
 install-plugin-xu1541: $(call CREATE_TARGET,$(SUBDIRS_PLUGIN_XU1541),install)
 ifeq "$(OS)" "Linux"
-	install -m 644 xu1541/udev/45-opencbm-xu1541.rules ${DESTDIR}/etc/udev/rules.d/
+	install -m 644 xu1541/udev/45-opencbm-xu1541.rules ${DESTDIR}/usr/lib/udev/rules.d/
 endif
 	install -d $(DESTDIR)$(PLUGINDIR)/xu1541
 	install -m 755 xu1541/misc/usb_echo_test xu1541/misc/read_event_log ${DESTDIR}/${PLUGINDIR}/xu1541/
@@ -107,7 +107,7 @@ $(call CREATE_TARGET,$(SUBDIRS_PLUGIN_XU1541),install):: plugin-xu1541
 
 install-plugin-xum1541: $(call CREATE_TARGET,$(SUBDIRS_PLUGIN_XUM1541),install)
 ifeq "$(OS)" "Linux"
-	install -m 644 xum1541/udev/45-opencbm-xum1541.rules ${DESTDIR}/etc/udev/rules.d/
+	install -m 644 xum1541/udev/45-opencbm-xum1541.rules ${DESTDIR}/usr/lib/udev/rules.d/
 endif
 
 $(call CREATE_TARGET,$(SUBDIRS_PLUGIN_XUM1541),install):: plugin-xum1541
@@ -142,9 +142,9 @@ $(call CREATE_TARGET,$(SUBDIRS_PLUGIN_XA1541),all):: opencbm
 plugin: $(PLUGINS)
 
 uninstall: $(call CREATE_TARGET,$(SUBDIRS_ALL_NON_OPTIONAL) $(SUBDIRS_OPTIONAL),uninstall)
-	rm ${DESTDIR}/etc/udev/rules.d/45-opencbm-xa1541.rules \
-	   ${DESTDIR}/etc/udev/rules.d/45-opencbm-xu1541.rules \
-	   ${DESTDIR}/etc/udev/rules.d/45-opencbm-xum1541.rules \
+	rm ${DESTDIR}/usr/lib/udev/rules.d/45-opencbm-xa1541.rules \
+	   ${DESTDIR}/usr/lib/udev/rules.d/45-opencbm-xu1541.rules \
+	   ${DESTDIR}/usr/lib/udev/rules.d/45-opencbm-xum1541.rules \
 	   ${DESTDIR}/etc/ld.so.conf.d/99-opencbm.conf \
 	   ${DESTDIR}/${PLUGINDIR}/xu1541/usb_echo_test \
 	   ${DESTDIR}/${PLUGINDIR}/xu1541/read_event_log \


### PR DESCRIPTION
udev rules shipped with various packages must be placed in /usr/lib/udev/rules.d/
udev rules written by the administrator go in /etc/udev/rules.d/
