### PR TITLE
Use of TAG+="uaccess" instead of GROUP and MODE

### DIFF
--- a/xu1541/udev/45-opencbm-xu1541.rules
+++ b/xu1541/udev/45-opencbm-xu1541.rules
@@ -1,6 +1,6 @@
 SUBSYSTEM!="usb_device", ACTION!="add", GOTO="opencbm_rules_end"
 
 # xu1541
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="c632", GROUP="users", MODE="0664"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="c632", TAG+="uaccess"
 
 LABEL="opencbm_rules_end"

--- a/xum1541/udev/45-opencbm-xum1541.rules
+++ b/xum1541/udev/45-opencbm-xum1541.rules
@@ -1,9 +1,9 @@
 SUBSYSTEM!="usb_device", ACTION!="add", GOTO="opencbm_rules_end"
 
 # xum1541
-SUBSYSTEM=="usb", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="0504", MODE="0664", GROUP="users"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="0504", TAG+="uaccess"
 
 # xum1541 in DFU mode
-SUBSYSTEM=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2ff0", MODE="0664", GROUP="users"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2ff0", TAG+="uaccess"
 
 LABEL="opencbm_rules_end"


### PR DESCRIPTION
Using static groups to grant unprivileged users device access is a concept which has been discouraged for a while. The recommended way is to use the uaccess tag but it is poorly documented:
https://github.com/systemd/systemd/issues/4288

Moreover, in most distributions (Fedora, Mageia, etc) users are not part of 'users' or other groups by default, therefore the current rule doesn't work.

