### PR TITLE
Switch to using libusb-compat port on OS X

### DIFF
--- a/opencbm/LINUX/config.make
+++ b/opencbm/LINUX/config.make
@@ -157,8 +157,8 @@ endif
 ifeq "$(OS)" "Darwin"
 ETCDIR=$(PREFIX)/etc
 
-# Use MacPort's libusb-legacy for now
-LIBUSB_CONFIG  = /opt/local/bin/libusb-legacy-config
+# Use MacPort's libusb-compat for now
+LIBUSB_CONFIG  = /opt/local/bin/libusb-config
 LIBUSB_CFLAGS  = $(shell $(LIBUSB_CONFIG) --cflags)
 LIBUSB_LDFLAGS =
 LIBUSB_LIBS    = $(shell $(LIBUSB_CONFIG) --libs)

--- a/opencbm/ports/MacPorts/Portfile
+++ b/opencbm/ports/MacPorts/Portfile
@@ -20,7 +20,7 @@ platforms           darwin
 homepage            https://sourceforge.net/projects/opencbm/
 
 depends_build       port:cc65
-depends_lib         port:libusb-legacy
+depends_lib         port:libusb-compat
 
 fetch.type          git
 git.url             https://github.com/OpenCBM/OpenCBM.git

--- a/xu1541/include/common.mk
+++ b/xu1541/include/common.mk
@@ -34,9 +34,9 @@ else
  ifeq "$(OS)" "Darwin"
    # MacOS compilation:
 
-   LIBUSB_DIR = $(shell libusb-legacy-config --prefix)
-   LDFLAGS_EXTRA = $(shell libusb-legacy-config --libs)
-   CFLAGS_EXTRA = $(shell libusb-legacy-config --cflags)
+   LIBUSB_DIR = $(shell libusb-config --prefix)
+   LDFLAGS_EXTRA = $(shell libusb-config --libs)
+   CFLAGS_EXTRA = $(shell libusb-config --cflags)
    
  else
    ifeq "$(shell uname -o)" "Cygwin"


### PR DESCRIPTION
Using this build I was able to see my attached ZoomFloppy under OS X 10.14.x Mojave, update it to the version 8 firmware and also read a disk with a connected 1571 drive.

Fixes #13 