### PR TITLE
add port:pkgconfig build dependency to Portfile

### DIFF
--- a/opencbm/ports/MacPorts/Portfile
+++ b/opencbm/ports/MacPorts/Portfile
@@ -19,7 +19,7 @@ long_description    The opencbm (cbm4linux) package contains user space \
 platforms           darwin
 homepage            https://sourceforge.net/projects/opencbm/
 
-depends_build       port:cc65
+depends_build       port:cc65 port:pkgconfig
 depends_lib         port:libusb-compat
 
 fetch.type          git


### PR DESCRIPTION
This PR adds the port `pkgconfig` to the MacPorts Portfile. The command `pkg-config` is already used by the Makefile to determine which versions of libusb are installed and get their compile flags. Without this build dependency, the port install of opencbm fails as described here: https://github.com/OpenCBM/OpenCBM/issues/16#issuecomment-538690534

Note: this does not resolve the original problem described in that issue! It's a separate problem.