### PR TITLE
xum1541: Fix baudrate calculation for serial debug output

### DIFF
--- a/xum1541/board-promicro.c
+++ b/xum1541/board-promicro.c
@@ -34,13 +34,19 @@ board_init(void)
     LED_PORT = LED_MASK;
 
 #ifdef DEBUG
+#define BAUD 115200
+#include <util/setbaud.h>
     /*
      * Initialize the UART baud rate at 115200 8N1 and select it for
      * printf() output.
      */
+#if USE_2X
     UCSR1A |= _BV(U2X1);
+#else
+    UCSR1A &= ~(_BV(U2X1));
+#endif
     UCSR1B |= _BV(TXEN1);
-    UBRR1 = 8;
+    UBRR1 = UBRR_VALUE;
     stdout = &mystdout;
 #endif
 

--- a/xum1541/board-promicro_7406.c
+++ b/xum1541/board-promicro_7406.c
@@ -34,13 +34,19 @@ board_init(void)
     LED_PORT = LED_MASK;
 
 #ifdef DEBUG
+#define BAUD 115200
+#include <util/setbaud.h>
     /*
      * Initialize the UART baud rate at 115200 8N1 and select it for
      * printf() output.
      */
+#if USE_2X
     UCSR1A |= _BV(U2X1);
+#else
+    UCSR1A &= ~(_BV(U2X1));
+#endif
     UCSR1B |= _BV(TXEN1);
-    UBRR1 = 8;
+    UBRR1 = UBRR_VALUE;
     stdout = &mystdout;
 #endif
 

--- a/xum1541/board-teensy2.c
+++ b/xum1541/board-teensy2.c
@@ -33,13 +33,19 @@ board_init(void)
     LED_PORT = LED_MASK;
 
 #ifdef DEBUG
+#define BAUD 115200
+#include <util/setbaud.h>
     /*
      * Initialize the UART baud rate at 115200 8N1 and select it for
      * printf() output.
      */
+#if USE_2X
     UCSR1A |= _BV(U2X1);
+#else
+    UCSR1A &= ~(_BV(U2X1));
+#endif
     UCSR1B |= _BV(TXEN1);
-    UBRR1 = 8;
+    UBRR1 = UBRR_VALUE;
     stdout = &mystdout;
 #endif
 

--- a/xum1541/board-usbkey.c
+++ b/xum1541/board-usbkey.c
@@ -29,13 +29,19 @@ void
 board_init(void)
 {
 #ifdef DEBUG
+#define BAUD 115200
+#include <util/setbaud.h>
     /*
      * Initialize the UART baud rate at 115200 8N1 and select it for
      * printf() output.
      */
+#if USE_2X
     UCSR1A |= _BV(U2X1);
+#else
+    UCSR1A &= ~(_BV(U2X1));
+#endif
     UCSR1B |= _BV(TXEN1);
-    UBRR1 = 8;
+    UBRR1 = UBRR_VALUE;
     stdout = &mystdout;
 #endif
 

--- a/xum1541/board-zoomfloppy.c
+++ b/xum1541/board-zoomfloppy.c
@@ -32,13 +32,19 @@ board_init(void)
     DDRC = LED_MASK;
 
 #ifdef DEBUG
+#define BAUD 115200
+#include <util/setbaud.h>
     /*
      * Initialize the UART baud rate at 115200 8N1 and select it for
      * printf() output.
      */
+#if USE_2X
     UCSR1A |= _BV(U2X1);
+#else
+    UCSR1A &= ~(_BV(U2X1));
+#endif
     UCSR1B |= _BV(TXEN1);
-    UBRR1 = 8;
+    UBRR1 = UBRR_VALUE;
     stdout = &mystdout;
 #endif
 


### PR DESCRIPTION
I have a 16 MHz pro micro board that I try to use with the xum1541 firmware.

I found that despite the comment in [`board_init()`](https://github.com/OpenCBM/OpenCBM/blob/f2bab60eca5101aa1c2d21126692efff6d14823d/xum1541/board-promicro_7406.c#L38) the serial debug output actually operates at 222222 baud.

This is consistent with what the [datasheet for the atmega32u4](http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-7766-8-bit-AVR-ATmega16U4-32U4_Datasheet.pdf) says about the formula setting up the UART baudrate in "asynchronous double speed mode" (page 191):

`baud = clock / (8 * (UBBR1 + 1))`

`board_init()` sets `UBBR1 = 8`, so `baud = 16E6 / (8 * 9) = 222222`.

8 seems to be the correct value for an 8 MHz clock rate, but it's used for all boards, regardless of the respective clock speed.

I've checked the datasheets of the MCUs set [for the various boards in `xum1541/Makefile`](https://github.com/OpenCBM/OpenCBM/blob/f2bab60eca5101aa1c2d21126692efff6d14823d/xum1541/Makefile#L43) and they all use the same formula for the baudrate calculation, so I guess all the non 8 MHz boards are affected. That's why I decided to open the PR here instead of over at [zyonee/opencbm](https://github.com/zyonee/opencbm), where the pro micro code originated.

I used the baudrate helper macros from [avr-libc's util/setbaud.h](https://www.nongnu.org/avr-libc/user-manual/group__util__setbaud.html) in the hope it makes the fix more future-proof.

I only own the pro micro board, so I obviously couldn't test it with any of the other variants. The code does at least compile for all the boards.

I tried to keep the changes minimal, that's why I put both `#define BAUD 115200` and `#include <util/setbaud.h>`next to the code that sets up the serial parameters in the `board_init()` functions. It might be nicer to define the baudrate in the Makefile together with the board specific parameters, but that makes it more likely to change the baudrate without changing the comment stating a baudrate of 115200.