### PR TITLE
Various fixes

### DIFF
--- a/opencbm/lib/plugin/xum1541/archlib.c
+++ b/opencbm/lib/plugin/xum1541/archlib.c
@@ -275,7 +275,7 @@ opencbm_plugin_listen(CBM_FILE HandleDevice, unsigned char DeviceAddress, unsign
     proto = XUM1541_CBM | XUM_WRITE_ATN;
     dataBuf[0] = 0x20 | DeviceAddress;
     dataBuf[1] = 0x60 | SecondaryAddress;
-    return !xum1541_write((struct opencbm_usb_handle *)HandleDevice, proto, dataBuf, sizeof(dataBuf));
+    return xum1541_write((struct opencbm_usb_handle *)HandleDevice, proto, dataBuf, sizeof(dataBuf)) <= 0;
 }
 
 /*! \brief Send a TALK on the IEC serial bus
@@ -309,7 +309,7 @@ opencbm_plugin_talk(CBM_FILE HandleDevice, unsigned char DeviceAddress, unsigned
     proto = XUM1541_CBM | XUM_WRITE_ATN | XUM_WRITE_TALK;
     dataBuf[0] = 0x40 | DeviceAddress;
     dataBuf[1] = 0x60 | SecondaryAddress;
-    return !xum1541_write((struct opencbm_usb_handle *)HandleDevice, proto, dataBuf, sizeof(dataBuf));
+    return xum1541_write((struct opencbm_usb_handle *)HandleDevice, proto, dataBuf, sizeof(dataBuf)) <= 0;
 }
 
 /*! \brief Open a file on the IEC serial bus
@@ -341,7 +341,7 @@ opencbm_plugin_open(CBM_FILE HandleDevice, unsigned char DeviceAddress, unsigned
     proto = XUM1541_CBM | XUM_WRITE_ATN;
     dataBuf[0] = 0x20 | DeviceAddress;
     dataBuf[1] = 0xf0 | SecondaryAddress;
-    return !xum1541_write((struct opencbm_usb_handle *)HandleDevice, proto, dataBuf, sizeof(dataBuf));
+    return xum1541_write((struct opencbm_usb_handle *)HandleDevice, proto, dataBuf, sizeof(dataBuf)) <= 0;
 }
 
 /*! \brief Close a file on the IEC serial bus
@@ -373,7 +373,7 @@ opencbm_plugin_close(CBM_FILE HandleDevice, unsigned char DeviceAddress, unsigne
     proto = XUM1541_CBM | XUM_WRITE_ATN;
     dataBuf[0] = 0x20 | DeviceAddress;
     dataBuf[1] = 0xe0 | SecondaryAddress;
-    return !xum1541_write((struct opencbm_usb_handle *)HandleDevice, proto, dataBuf, sizeof(dataBuf));
+    return xum1541_write((struct opencbm_usb_handle *)HandleDevice, proto, dataBuf, sizeof(dataBuf)) <= 0;
 }
 
 /*! \brief Send an UNLISTEN on the IEC serial bus
@@ -403,7 +403,7 @@ opencbm_plugin_unlisten(CBM_FILE HandleDevice)
 
     proto = XUM1541_CBM | XUM_WRITE_ATN;
     dataBuf[0] = 0x3f;
-    return !xum1541_write((struct opencbm_usb_handle *)HandleDevice, proto, dataBuf, sizeof(dataBuf));
+    return xum1541_write((struct opencbm_usb_handle *)HandleDevice, proto, dataBuf, sizeof(dataBuf)) <= 0;
 }
 
 /*! \brief Send an UNTALK on the IEC serial bus
@@ -433,7 +433,7 @@ opencbm_plugin_untalk(CBM_FILE HandleDevice)
 
     proto = XUM1541_CBM | XUM_WRITE_ATN;
     dataBuf[0] = 0x5f;
-    return !xum1541_write((struct opencbm_usb_handle *)HandleDevice, proto, dataBuf, sizeof(dataBuf));
+    return xum1541_write((struct opencbm_usb_handle *)HandleDevice, proto, dataBuf, sizeof(dataBuf)) <= 0;
 }
 
 

--- a/opencbm/lib/plugin/xum1541/xum1541.c
+++ b/opencbm/lib/plugin/xum1541/xum1541.c
@@ -654,31 +654,35 @@ xum1541_close(struct opencbm_usb_handle *HandleXum1541)
 
     xum1541_dbg(0, "Closing USB link");
 
+    if (HandleXum1541->devh != NULL) {
 #if HAVE_LIBUSB0
-    ret = usb.control_msg(HandleXum1541->devh, USB_TYPE_CLASS | USB_ENDPOINT_OUT,
-        XUM1541_SHUTDOWN, 0, 0, NULL, 0, 1000);
+        ret = usb.control_msg(HandleXum1541->devh, USB_TYPE_CLASS | USB_ENDPOINT_OUT,
+            XUM1541_SHUTDOWN, 0, 0, NULL, 0, 1000);
 #elif HAVE_LIBUSB1
-    ret = usb.control_transfer(HandleXum1541->devh, LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_ENDPOINT_OUT,
-        XUM1541_SHUTDOWN, 0, 0, NULL, 0, 1000);
+        ret = usb.control_transfer(HandleXum1541->devh, LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_ENDPOINT_OUT,
+            XUM1541_SHUTDOWN, 0, 0, NULL, 0, 1000);
 #endif
-    if (ret < 0) {
-        fprintf(stderr,
-            "USB request for XUM1541 close failed, continuing: %s\n",
-            usb.error_name(ret));
-    }
-    ret = usb.release_interface(HandleXum1541->devh, 0);
-    if (ret != LIBUSB_SUCCESS)
-        fprintf(stderr, "USB release intf error: %s\n", usb.error_name(ret));
+        if (ret < 0) {
+            fprintf(stderr,
+                "USB request for XUM1541 close failed, continuing: %s\n",
+                usb.error_name(ret));
+        }
+        ret = usb.release_interface(HandleXum1541->devh, 0);
+        if (ret != LIBUSB_SUCCESS)
+            fprintf(stderr, "USB release intf error: %s\n", usb.error_name(ret));
 
     ret = usb.set_configuration(HandleXum1541->devh, -1);
     if (ret != LIBUSB_SUCCESS) {
         fprintf(stderr, "USB deconfig device error: %d %s\n", ret, usb.error_name(ret));
     }
 #if HAVE_LIBUSB0
-    if (usb.close(HandleXum1541->devh) != LIBUSB_SUCCESS)
-        fprintf(stderr, "USB close error: %s\n", usb.strerror());
+        if (usb.close(HandleXum1541->devh) != LIBUSB_SUCCESS)
+            fprintf(stderr, "USB close error: %s\n", usb.strerror());
 #elif HAVE_LIBUSB1
-    usb.close(HandleXum1541->devh);
+        usb.close(HandleXum1541->devh);
+    }
+#endif
+#if HAVE_LIBUSB1
     usb.exit(HandleXum1541->ctx);
 #endif
 

--- a/opencbm/lib/plugin/xum1541/xum1541.c
+++ b/opencbm/lib/plugin/xum1541/xum1541.c
@@ -426,14 +426,11 @@ xum1541_device_path(int PortNumber)
             usb.get_bus_number(usb.get_device(HandleXum1541.devh)),
             usb.get_device_address(usb.get_device(HandleXum1541.devh)));
 #endif
-        xum1541_close(&HandleXum1541);
     } else {
         fprintf(stderr, "error: no xum1541 device found\n");
     }
 
-#if HAVE_LIBUSB1
-    usb.exit(HandleXum1541.ctx);
-#endif
+    xum1541_close(&HandleXum1541);
 
     return dev_path;
 }

--- a/opencbm/lib/plugin/xum1541/xum1541.c
+++ b/opencbm/lib/plugin/xum1541/xum1541.c
@@ -385,14 +385,7 @@ xum1541_check_version(int version)
    The device's serial number to search for also. It is not considered, if set to 0.
 
   \return
-    0 on success, -1 on error. On error, the handle is cleaned up if it
-    was already active.
-
-  \remark
-    On success, xum1541_handle contains a valid handle to the xum1541 device.
-    In this case, the device configuration has been set and the interface
-    been claimed. xum1541_close() should be called when the user is done
-    with it.
+    device identifier string on success, NULL on error.
 */
 const char *
 xum1541_device_path(int PortNumber)

--- a/opencbm/lib/plugin/xum1541/xum1541.c
+++ b/opencbm/lib/plugin/xum1541/xum1541.c
@@ -140,7 +140,7 @@ xum1541_cleanup(struct opencbm_usb_handle *HandleXum1541, char *msg, ...)
 
     if (msg != NULL) {
         va_start(args, msg);
-        fprintf(stderr, msg, args);
+        vfprintf(stderr, msg, args);
         va_end(args);
     }
     if (HandleXum1541 != NULL) {

--- a/opencbm/lib/plugin/xum1541/xum1541.c
+++ b/opencbm/lib/plugin/xum1541/xum1541.c
@@ -514,7 +514,6 @@ xum1541_init(struct opencbm_usb_handle **HandleXum1541_p, int PortNumber)
     struct opencbm_usb_handle *HandleXum1541;
     unsigned char devInfo[XUM_DEVINFO_SIZE], devStatus;
     int len, ret;
-    int interface_claimed = 0;
     int success = 0;
 
     if (HandleXum1541_p == NULL) {
@@ -569,10 +568,6 @@ xum1541_init(struct opencbm_usb_handle **HandleXum1541_p, int PortNumber)
             xum1541_cleanup(HandleXum1541, "USB error: %s\n", usb.error_name(ret));
             break;
         }
-
-#if HAVE_LIBUSB1
-        interface_claimed = 1;
-#endif
 
         // Check the basic device info message for firmware version
         memset(devInfo, 0, sizeof(devInfo));
@@ -630,10 +625,6 @@ xum1541_init(struct opencbm_usb_handle **HandleXum1541_p, int PortNumber)
 
     /* error cleanup */
     if (!success) {
-        if (interface_claimed) {
-            usb.release_interface(HandleXum1541->devh, 0);
-        }
-
         xum1541_close(HandleXum1541);
     }
 
@@ -668,17 +659,21 @@ xum1541_close(struct opencbm_usb_handle *HandleXum1541)
                 usb.error_name(ret));
         }
         ret = usb.release_interface(HandleXum1541->devh, 0);
-        if (ret != LIBUSB_SUCCESS)
-            fprintf(stderr, "USB release intf error: %s\n", usb.error_name(ret));
 
     ret = usb.set_configuration(HandleXum1541->devh, -1);
     if (ret != LIBUSB_SUCCESS) {
         fprintf(stderr, "USB deconfig device error: %d %s\n", ret, usb.error_name(ret));
     }
 #if HAVE_LIBUSB0
+        // ENOENT could mean the interface was never claimed
+        if (ret != LIBUSB_SUCCESS && ret != -ENOENT)
+        fprintf(stderr, "USB release intf error: %d %s\n", ret, usb.error_name(ret));
         if (usb.close(HandleXum1541->devh) != LIBUSB_SUCCESS)
             fprintf(stderr, "USB close error: %s\n", usb.strerror());
 #elif HAVE_LIBUSB1
+        // LIBUSB_ERROR_NOT_FOUND means the interface was never claimed
+        if (ret != LIBUSB_SUCCESS && ret != LIBUSB_ERROR_NOT_FOUND)
+            fprintf(stderr, "USB release intf error: %d %s\n", ret, usb.error_name(ret));
         usb.close(HandleXum1541->devh);
     }
 #endif

--- a/opencbm/lib/plugin/xum1541/xum1541.c
+++ b/opencbm/lib/plugin/xum1541/xum1541.c
@@ -544,18 +544,16 @@ xum1541_init(struct opencbm_usb_handle **HandleXum1541_p, int PortNumber)
         // Select first and only device configuration.
         ret = usb.set_configuration(HandleXum1541->devh, 1);
         if (ret != LIBUSB_SUCCESS) {
-            xum1541_cleanup(HandleXum1541, "USB error: %s\n", usb.error_name(ret));
+            fprintf(stderr, "USB error: %s\n", usb.error_name(ret));
             break;
         }
 
         /*
          * Get exclusive access to interface 0.
-         * After this point, do cleanup using xum1541_close() instead of
-         * xum1541_cleanup().
          */
         ret = usb.claim_interface(HandleXum1541->devh, 0);
         if (ret != LIBUSB_SUCCESS) {
-            xum1541_cleanup(HandleXum1541, "USB error: %s\n", usb.error_name(ret));
+            fprintf(stderr, "USB error: %s\n", usb.error_name(ret));
             break;
         }
 

--- a/opencbm/lib/plugin/xum1541/xum1541.c
+++ b/opencbm/lib/plugin/xum1541/xum1541.c
@@ -536,7 +536,7 @@ xum1541_init(struct opencbm_usb_handle **HandleXum1541_p, int PortNumber)
         usb.exit(HandleXum1541->ctx);
 #endif
         free(HandleXum1541);
-        HandleXum1541 = NULL;
+        *HandleXum1541_p = NULL;
         return -1;
     }
 
@@ -616,6 +616,7 @@ xum1541_init(struct opencbm_usb_handle **HandleXum1541_p, int PortNumber)
     /* error cleanup */
     if (!success) {
         xum1541_close(HandleXum1541);
+        *HandleXum1541_p = NULL;
     }
 
     return success ? 0 : -1;

--- a/xum1541cfg/util.c
+++ b/xum1541cfg/util.c
@@ -104,7 +104,7 @@ xum1541_cleanup(libusb_device_handle **usbHandle, char *msg, ...)
 
     if (msg != NULL) {
         va_start(args, msg);
-        fprintf(stderr, msg, args);
+        vfprintf(stderr, msg, args);
         va_end(args);
     }
     if (*usbHandle != NULL) {


### PR DESCRIPTION
These are the bug fixes that I talked about earlier today in the zoomfloppy-users group.

Except for 02cb6ec I had them in my tree for some time so they got some marginal testing. I also checked the result of applying all of them to current HEAD and did quick checks with cbmctrl status/dir, d64copy and nibread without finding any problems.

Many of the commits are mostly cosmetic or fix only minor issues with the following exceptions:

- 1fe8dc4 fixes a crash when no usb adapter is connected. You should see that too, right? It's not a big problem as the command obviously wouldn't work anyway.
- 74fe6d9 could expose bugs in tools that might now crash when using a stale device handle. I haven't found any, but I only tested a few. I would still find it beneficial to apply the patch and fix the other tools when errors pop up.
- 9a1440a could also lead to problems if any of the callers don't correctly handle when these functions now return an (valid) error. I found no problems, but that doesn't mean much.

Sorry for putting all commits into a single PR. They should be independent, though, so you should be able to cherry-pick the ones you feel comfortable applying.