### PR TITLE
explicitly cast off_t to long for printing

### DIFF
--- a/opencbm/libimgcopy/fs.c
+++ b/opencbm/libimgcopy/fs.c
@@ -121,7 +121,7 @@ static int open_disk(CBM_FILE fd, imgcopy_settings *settings,
         }
         else
         {
-            printf("filesize=%ld, blockcount=%d, calc1=%d, calc2=%d\n", filesize, block_count, block_count * (BLOCKSIZE), block_count * (BLOCKSIZE + 1));
+            printf("filesize=%ld, blockcount=%d, calc1=%d, calc2=%d\n", (long)filesize, block_count, block_count * (BLOCKSIZE), block_count * (BLOCKSIZE + 1));
             /*   D64 sonderformate
 
                  for( tr = D82_TRACKS; !is_image && tr <= D82_TRACKS; )


### PR DESCRIPTION
As far as I know, there's no guarantee about the size of an `off_t`, and a wrong size when calling a variadic function is dangerous. Therefore I think it's a reasonable portability fix to explicitly cast `off_t` to `long` for printing it.