### PR TITLE
Improve filename handling in cbmcopy

### DIFF
--- a/opencbm/cbmcopy/main.c
+++ b/opencbm/cbmcopy/main.c
@@ -497,10 +497,14 @@ int ARCH_MAINDECL main(int argc, char **argv)
                                 /* no charset conversion */
                                 strncpy(buf, auto_name, 16);
                             }
-                            strcat(buf, ",x");
-                            buf[strlen(buf)-1] =
-                                output_type ? output_type : auto_type;
-                            strcat(buf, ",W");
+                            for(tail = buf; *tail; tail++)
+                            {
+                                /* replace illegal characters in CBM filename */
+                                if(strchr(":?*,=", *tail)) *tail = ' ';
+                            }
+                            *tail++ = ',';
+                            *tail++ = output_type ? output_type : auto_type;
+                            strcpy(tail, ",W");
 
                             my_message_cb( sev_info,
                                            "writing %s -> %s", fname, buf );

--- a/opencbm/cbmcopy/main.c
+++ b/opencbm/cbmcopy/main.c
@@ -576,18 +576,21 @@ int ARCH_MAINDECL main(int argc, char **argv)
                             case 'u': ext = "usr"; break;
                         }
                     }
-                    fs_name = malloc(strlen(fname) + strlen(ext) + 2);
-                    if(fs_name) sprintf(fs_name, "%s.%s", fname, ext);
-                }
 
-                if(fs_name)
-                {
-                    for(tail = fs_name; *tail; tail++)
+                    fs_name = malloc(strlen(fname) + strlen(ext) + 2);
+                    if(fs_name)
                     {
-                        if(*tail == '/') *tail = '_';
+                        strcpy(fs_name, fname);
+                        for(tail = fs_name; *tail; tail++)
+                        {
+                            if(*tail == '/') *tail = '_';
+                        }
+                        *tail++ = '.';
+                        strcpy(tail, ext);
                     }
                 }
-                else
+
+                if(!fs_name)
                 {
                     /* should not happen... */
                     cbm_driver_close( fd );

--- a/opencbm/cbmcopy/main.c
+++ b/opencbm/cbmcopy/main.c
@@ -583,7 +583,7 @@ int ARCH_MAINDECL main(int argc, char **argv)
                         strcpy(fs_name, fname);
                         for(tail = fs_name; *tail; tail++)
                         {
-                            if(*tail == '/') *tail = '_';
+                            if(strchr("\\/\"<>|", *tail)) *tail = '_';
                         }
                         *tail++ = '.';
                         strcpy(tail, ext);

--- a/opencbm/cbmcopy/main.c
+++ b/opencbm/cbmcopy/main.c
@@ -506,8 +506,17 @@ int ARCH_MAINDECL main(int argc, char **argv)
                             *tail++ = output_type ? output_type : auto_type;
                             strcpy(tail, ",W");
 
+                            /* convert result to ASCII for display */
+                            tail = strdup(buf);
+                            /* use buf as fallback if allocation failed */
+                            if(tail) cbm_petscii2ascii(tail);
+                            else tail = buf;
+
                             my_message_cb( sev_info,
-                                           "writing %s -> %s", fname, buf );
+                                           "writing %s -> %s", fname, tail );
+
+                            /* tail == buf means allocation failed */
+                            if(tail != buf) free(tail);
 
                             if(address >= 0 && filesize > 1)
                             {

--- a/opencbm/cbmcopy/raw.c
+++ b/opencbm/cbmcopy/raw.c
@@ -39,7 +39,26 @@ static int read(FILE *file, const char *fname, int entry,
         }
     }
 
+    *type = 'P';
     strncpy(cbmname, tail ? tail+1 : fname, 16);
+    tail = strrchr(cbmname, '.');
+    if(tail)
+    {
+        if (strcasecmp(tail, ".prg") == 0)
+        {
+            *tail = '\0';
+        }
+        else if (strcasecmp(tail, ".seq") == 0)
+        {
+            *type = 'S';
+            *tail = '\0';
+        }
+        else if (strcasecmp(tail, ".usr") == 0)
+        {
+            *type = 'U';
+            *tail = '\0';
+        }
+    }
     for(tail = cbmname; *tail; tail++)
     {
         switch(*tail)
@@ -52,7 +71,6 @@ static int read(FILE *file, const char *fname, int entry,
                 break;
         }
     }
-    *type = 'P';
     *data = NULL;
 
     if(entry == 0 && fseek( file, 0L, SEEK_END ) == 0 )


### PR DESCRIPTION
This PR fixes the issues discussed in #79:

- `cbmread` replaces even slashes in the filename given by the "-o" option with underscores. This makes it impossible to write the output to anywhere but the current directory (c8c5f07).
- `cbmread` adds an extension that reflects the CBM filetype ("`.prg`", "`.seq`", ...), but `cbmwrite` doesn't remove it and neither sets the filetype accordingly (b40f163).

It also addresses these additional issues I found while looking into this:

- A slash isn't the only problematic character that is valid for a filename in CBM DOS. [According to Wikipedia](https://en.wikipedia.org/wiki/Comparison_of_file_systems#Limits), `\`, `"`, `<`, `>` and `|` are illegal for FAT and NTFS as well. And while they are legal for ext2/3/4, they are still annoying even on Linux, as the shell treats them as special characters. That's why I don't differentiate between Windows and Linux (044b8b5).
- While we're at it, also replace characters that are illegal for CBM DOS with a space in `cbmwrite` (ac47a80).
- `cbmwrite` uses the filename in PETSCII format for its status message ("writing x -> y"). This displays garbage when the filename contains uppercase PETSCII characters, as they are not valid ASCII characters. So make a temporary copy of the filename, convert it to ASCII and use that for the status message (35e143f).

Some remarks:

- `cbmread` also creates files with a "`.del`" extension (is it even possible to read them?). As I wasn't able to create them, even by using a "D" filetype, I didn't bother to handle them when writing.
- Some of these changes are not backwards compatible and might have an negative impact (especially GUI front ends come to mind):
  - c8c5f07 and 044b8b5 because files might now end up with a different name and even in a different directory than expected.
  - b40f163 because a file might end up on the floppy drive with the extension removed and a different filetype. 
  - 35e143f because it changes the case of both the filename and the filetype and operation characters in the status message. This could be changed, but I'd argue that the new version is correct.
- Tested on Linux, but not on Windows.