### PR TITLE
Fix Wstringop-truncation, replace strncpy() with sprintf()

### DIFF
--- a/opencbm/cbmcopy/main.c
+++ b/opencbm/cbmcopy/main.c
@@ -486,7 +486,6 @@ int ARCH_MAINDECL main(int argc, char **argv)
                                     auto_name, &auto_type,
                                     &filedata, &filesize, my_message_cb ) == 0)
                         {
-                            buf[16] = '\0';
                             if(output_name)
                             {
                                 sprintf(buf, "%.16s", output_name);

--- a/opencbm/cbmcopy/main.c
+++ b/opencbm/cbmcopy/main.c
@@ -488,13 +488,15 @@ int ARCH_MAINDECL main(int argc, char **argv)
                         {
                             if(output_name)
                             {
-                                sprintf(buf, "%.16s", output_name);
+                                strncpy(buf, output_name, 16);
+                                buf[16] = '\0';
                                 cbm_ascii2petscii(buf);
                             }
                             else
                             {
                                 /* no charset conversion */
-                                sprintf(buf, "%.16s", auto_name);
+                                strncpy(buf, auto_name, 16);
+                                buf[16] = '\0';
                             }
                             strcat(buf, ",x");
                             buf[strlen(buf)-1] =

--- a/opencbm/cbmcopy/main.c
+++ b/opencbm/cbmcopy/main.c
@@ -489,13 +489,13 @@ int ARCH_MAINDECL main(int argc, char **argv)
                             buf[16] = '\0';
                             if(output_name)
                             {
-                                strncpy(buf, output_name, 16);
+                                sprintf(buf, "%.16s", output_name);
                                 cbm_ascii2petscii(buf);
                             }
                             else
                             {
                                 /* no charset conversion */
-                                strncpy(buf, auto_name, 16);
+                                sprintf(buf, "%.16s", auto_name);
                             }
                             strcat(buf, ",x");
                             buf[strlen(buf)-1] =


### PR DESCRIPTION
Found with gcc 10.2.0

`strncpy()` is for fixed-length records, the remainder of dst is filled with '\0' characters. Its generally a poor choice for processing text, its not a safer version of `strcpy()` and in this case, `s(n)printf()` is a better choice for truncating strings.

Before:
```
gcc -g -I..//libcbmcopy -O2 -D_FORTIFY_SOURCE=2 -Wall -I../include -I../include/LINUX -DPREFIX=\"/usr/local\" -DOPENCBM_CONFIG_FILE=\"/etc/opencbm.conf\" -fstack-protector  -o main.o -c main.c
In file included from /usr/include/string.h:519,
                 from main.c:18:
In function ‘strncpy’,
    inlined from ‘main’ at main.c:498:33:
/usr/include/bits/string_fortified.h:95:10: warning: ‘__builtin_strncpy’ output may be truncated copying 16 bytes from a string of length 16 [-Wstringop-truncation]
   95 |   return __builtin___strncpy_chk (__dest, __src, __len,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   96 |       __glibc_objsize (__dest));
      |
```
After:
`gcc -g -I..//libcbmcopy -O2 -D_FORTIFY_SOURCE=2 -Wall -I../include -I../include/LINUX -DPREFIX=\"/usr/local\" -DOPENCBM_CONFIG_FILE=\"/etc/opencbm.conf\" -fstack-protector  -o main.o -c main.c`

I did no functional test, only compile test.