### PR TITLE
Pro Micro models: Do a WD reset if USB was enabled by the bootloader

### DIFF
--- a/xum1541/cpu-promicro.h
+++ b/xum1541/cpu-promicro.h
@@ -21,6 +21,13 @@ cpu_init(void)
 
     // Enable watchdog timer and set for 1 second.
     wdt_enable(WDTO_1S);
+
+    // Do a clean restart via WD reset if USB was already enabled by the
+    // bootloader. Otherwise the VBUSTI interrupt, that main() is waiting
+    // for, might never happen.
+    if (USBCON & _BV(USBE))
+        while (true)
+            ;
 }
 
 static inline void


### PR DESCRIPTION
I finally investigated why my Pro Micro based xum1541 devices sometimes wouldn't work after a restart (for example after an external reset).

Turns out there are multiple problems, which are all caused by the fact that the Arduino "Caterina" based bootloaders don't perform a proper reset after they entered programming mode and instead just do a jump to the main program, which leaves the USB initialised.

Most notably, this means the `EVENT_USB_Device_Connect()` callback (which would set the `usb_connected` flag) is never delivered and [therefore the xum1541 gets stuck](https://github.com/OpenCBM/OpenCBM/blob/c3970b825881c6d2b0263731a98fc1e2ff2f1f9f/xum1541/main.c#L48).

I solved this by forcing a WD reset in the Pro Micro's `cpu_init()` if it detects that USB has already been enabled. Seems to work fine. I consider this the best solution, mostly because it doesn't affect the other boards. 

At least for me, this also reliably solves the problem that the device might not work if it was connected to a powered CBM device before USB got plugged in.
