### PR TITLE
xum1541: Include details of compilation environment in firmware

### DIFF
--- a/xum1541/Makefile
+++ b/xum1541/Makefile
@@ -83,10 +83,14 @@ MODELVERSION= xum1541-$(MODEL)-v$(XUMFW_VERSION)
 # Resulting full revision number for model and firmware version
 REVISION=$(shell grep '\#define $(MODEL)' xum1541.h | sed 's/\#define $(MODEL)//' | xargs printf "%02X")$(XUMFW_VERSION)
 
+# git revision or "unknown" if either not a git repo or git command unavailable
+GITREV=$(shell git describe --always --exclude '*' || echo 'unknown')
+
 # If we wanted to reduce inlining to save size, these flags might be a
 # good start:
 #   --param inline-call-cost=2 -finline-limit=3 -fno-inline-small-functions
 CFLAGS+= -DMODEL=$(MODEL) -DMODELNAME=\"$(MODEL)\" -DBOARD=$(BOARD) \
+        -D__XUM1541_GIT_REVISION__="\"$(GITREV)\"" \
         -DF_CPU=$(CPURATE)UL -DF_CLOCK=F_CPU -mmcu=$(CPUMODEL) \
         -Os -g -Werror -Wall -Wstrict-prototypes -Wundef \
         -Winline -Wno-error=inline -std=gnu99 -I . \

--- a/xum1541/commands.c
+++ b/xum1541/commands.c
@@ -574,6 +574,15 @@ enterBootLoader(void)
 }
 
 /*
+ * git revision (if known) plus gcc and libc version strings for XUM1541_GITREV,
+ * XUM1541_GCCVER and XUM1541_LIBCVER control messages.
+ * To be used by the host in diagnostic messages.
+ */
+static const char gitRevision[] PROGMEM = __XUM1541_GIT_REVISION__;
+static const char gccVersion[] PROGMEM = __VERSION__;
+static const char libcVersion[] PROGMEM = __AVR_LIBC_VERSION_STRING__;
+
+/*
  * Process the given USB control command, storing the result in replyBuf
  * and returning the number of output bytes. Returns -1 if command is
  * invalid. All control processing has to happen until completion (no
@@ -645,6 +654,15 @@ usbHandleControl(uint8_t cmd, uint8_t *replyBuf)
         cmds->cbm_reset(false);
         return 0;
 #endif // TAPE_SUPPORT
+    case XUM1541_GITREV:
+        strncpy_P((char *)replyBuf, gitRevision, XUM_DEVINFO_SIZE);
+        return XUM_DEVINFO_SIZE;
+    case XUM1541_GCCVER:
+        strncpy_P((char *)replyBuf, gccVersion, XUM_DEVINFO_SIZE);
+        return XUM_DEVINFO_SIZE;
+    case XUM1541_LIBCVER:
+        strncpy_P((char *)replyBuf, libcVersion, XUM_DEVINFO_SIZE);
+        return XUM_DEVINFO_SIZE;
     default:
         DEBUGF(DBG_ERROR, "ERR: control cmd %d not impl\n", cmd);
         return -1;

--- a/xum1541/xum1541_types.h
+++ b/xum1541/xum1541_types.h
@@ -30,6 +30,9 @@
 #define XUM1541_SHUTDOWN            (XUM1541_ECHO + 3)
 #define XUM1541_ENTER_BOOTLOADER    (XUM1541_ECHO + 4)
 #define XUM1541_TAP_BREAK           (XUM1541_ECHO + 5)
+#define XUM1541_GITREV              (XUM1541_ECHO + 6)
+#define XUM1541_GCCVER              (XUM1541_ECHO + 7)
+#define XUM1541_LIBCVER             (XUM1541_ECHO + 8)
 
 // Adapter capabilities, but device may not support them
 #define XUM1541_CAP_CBM             0x01 // supports CBM commands


### PR DESCRIPTION
I propose to include the git revision and the avr-gcc/libs versions in the xum1541 firmware, so they can be included in the `XUM1541_DEBUG` the log by the plugin.

Example output:

```
[XUM1541] firmware version 8, library version 8
[XUM1541] device capabilities 03 status 00
[XUM1541] [xum1541_init] No tape support.
[XUM1541] firmware git revision is 38fdf837
[XUM1541] compiled with avr-gcc version 11.2.0
[XUM1541] and using avr-libc version 2.0.0
```

The additional information should help with analysing problem reports.

I tried to keep the changes minimal, this is why the individual values are limited to 8 byte each.

The feature should be backwards compatible, so I think this can be merged without increasing the xum1541 firmware version: If the firmware doesn't support the new USB control messages, the plugin just ignores the error. Likewise, it should be no problem to use a new firmware with an older plugin, as the messages will just not be sent.

Tested on Linux with the Pro Micro adapter.