### PR TITLE
[xu1541] Fix builds under FreeBSD - use $(MAKE) instead of make directly

### DIFF
--- a/xu1541/Makefile
+++ b/xu1541/Makefile
@@ -14,7 +14,7 @@ clean:
 all-linux: xu1541lib misc update_tool firmware bootloader update-bootloader
 
 firmware firmware/firmware.hex:
-	make -C firmware
+	$(MAKE) -C firmware
 
 firmware-avrusb: firmware/firmware.hex bootloader/bootloader-avrusb.hex
 	(head -n -1 firmware/firmware.hex; cat bootloader/bootldr-avrusb.hex) > firmware+bootloader-avrusb.hex
@@ -25,36 +25,36 @@ firmware-usbtiny: firmware/firmware.hex bootloader/bootloader-usbtiny.hex
 bootloader: bootloader-avrusb bootloader-usbtiny
 
 bootloader-avrusb bootloader/bootloader-avrusb.hex:
-	make -C bootloader -f Makefile-avrusb
+	$(MAKE) -C bootloader -f Makefile-avrusb
 
 bootloader-usbtiny bootloader/bootloader-usbtiny.hex:
-	make -C bootloader -f Makefile-usbtiny
+	$(MAKE) -C bootloader -f Makefile-usbtiny
 
 update-bootloader:
-	make -C update-bootloader
+	$(MAKE) -C update-bootloader
 
 misc:
-	make -C misc/
+	$(MAKE) -C misc/
 
 update_tool:
-	make -C update_tool/src/
+	$(MAKE) -C update_tool/src/
 
 program-avrusb: bootloader-avrusb
-	make -C bootloader -f Makefile-avrusb program
+	$(MAKE) -C bootloader -f Makefile-avrusb program
 
 program-usbtiny: bootloader-usbtiny
-	make -C bootloader -f Makefile-usbtiny program
+	$(MAKE) -C bootloader -f Makefile-usbtiny program
 
 update-firmware: firmware update_tool
 	./update_tool/xu1541_update ./firmware/firmware.hex
 
 update-bios-avrusb: update-avrusb
 update-avrusb: bootloader-avrusb update_tool update-bootloader
-	make -C update-bootloader program-avrusb
+	$(MAKE) -C update-bootloader program-avrusb
 
 update-bios-usbtiny: update-usbtiny
 update-usbtiny: bootloader-usbtiny update_tool update-bootloader
-	make -C update-bootloader program-usbtiny
+	$(MAKE) -C update-bootloader program-usbtiny
 
 update-all-avrusb: bootloader-avrusb update_tool update-bootloader firmware
 	./update_tool/xu1541_update ./update-bootloader/flash-firmware.hex -o=0x1000 ./bootloader/bootldr-avrusb.hex -R ./firmware/firmware.hex
@@ -63,22 +63,22 @@ update-all-usbtiny: bootloader-usbtiny update_tool update-bootloader firmware
 	./update_tool/xu1541_update ./update-bootloader/flash-firmware.hex -o=0x1000 ./bootloader/bootldr-usbtiny.hex -R ./firmware/firmware.hex
 
 diff:
-	make distclean
+	$(MAKE) distclean
 	cvs diff|view -
 
 terminal:
-	make -C update-bootloader terminal
+	$(MAKE) -C update-bootloader terminal
 
 version: misc
 	./misc/usb_echo_test
 
 xu1541lib:
-	make -C lib
+	$(MAKE) -C lib
 
 xmingw:
-	(export MINGW=1; make -C lib/)
-	(export MINGW=1; make -C misc/)
-	(export MINGW=1; make -C update_tool/src/)
+	(export MINGW=1; $(MAKE) -C lib/)
+	(export MINGW=1; $(MAKE) -C misc/)
+	(export MINGW=1; $(MAKE) -C update_tool/src/)
 
 exe:	misc update_tool
 

--- a/xu1541/update_tool/src/Makefile
+++ b/xu1541/update_tool/src/Makefile
@@ -23,7 +23,7 @@ LFLAGS := -L../../lib/ -lxu1541$(LIB_WIN) $(LFLAGS)
 .PHONY:	all clean mrproper xu1541lib
 
 all:
-	make ../$(APP)
+	$(MAKE) ../$(APP)
 
 clean:
 	rm -f *.o *~
@@ -35,4 +35,4 @@ mrproper: clean
 	$(CC) $(OBJS) -o $@ $(LFLAGS)
 
 xu1541lib:
-	make -C ../../lib/
+	$(MAKE) -C ../../lib/


### PR DESCRIPTION
On FreeBSD (and other BSD systems) the default make is BSD Make, not GNU Make.
However, these are GNU Makefiles.  So, when make is called like this, it
calls BSD Make and everything falls apart.

Use $(MAKE) so the current make program is used.

Tested:

* FreeBSD-14.0-CURRENT