### PR TITLE
cbmcopy: Fixes for remote filename handling

### DIFF
--- a/opencbm/cbmcopy/main.c
+++ b/opencbm/cbmcopy/main.c
@@ -30,6 +30,8 @@
 #include "statedebug.h"
 
 
+#define FN_BUFFER_SIZE 48
+
 /* global, because of signal handler */
 static CBM_FILE fd_cbm;
 
@@ -180,7 +182,7 @@ int ARCH_MAINDECL main(int argc, char **argv)
     int option;
     unsigned char *filedata;
     size_t filesize;
-    char buf[48];
+    char buf[FN_BUFFER_SIZE];
     int num_entries;
     int num_files;
     int rv;
@@ -488,8 +490,9 @@ int ARCH_MAINDECL main(int argc, char **argv)
                         {
                             if(output_name)
                             {
-                                strncpy(buf, output_name, 16);
-                                buf[16] = '\0';
+                                /* leave room for file type, mode and '\0'  */
+                                strncpy(buf, output_name, sizeof(buf)-5);
+                                buf[sizeof(buf)-5] = '\0';
                                 cbm_ascii2petscii(buf);
 
                                 tail = strchr(buf, '\0');
@@ -569,8 +572,9 @@ int ARCH_MAINDECL main(int argc, char **argv)
             }
             else
             {
-                strncpy(buf, fname, 16);
-                buf[16] = '\0';
+                /* leave room for file type and '\0' */
+                strncpy(buf, fname, sizeof(buf)-3);
+                buf[sizeof(buf)-3] = '\0';
                 cbm_ascii2petscii(buf);
 
                 if(output_name)

--- a/opencbm/cbmcopy/main.c
+++ b/opencbm/cbmcopy/main.c
@@ -491,17 +491,20 @@ int ARCH_MAINDECL main(int argc, char **argv)
                                 strncpy(buf, output_name, 16);
                                 buf[16] = '\0';
                                 cbm_ascii2petscii(buf);
+
+                                tail = strchr(buf, '\0');
                             }
                             else
                             {
                                 /* no charset conversion */
                                 strncpy(buf, auto_name, 16);
                                 buf[16] = '\0';
-                            }
-                            for(tail = buf; *tail; tail++)
-                            {
-                                /* replace illegal characters in CBM filename */
-                                if(strchr(":?*,=", *tail)) *tail = ' ';
+
+                                for(tail = buf; *tail; tail++)
+                                {
+                                    /* replace illegal characters in CBM filename */
+                                    if(strchr(":?*,=", *tail)) *tail = ' ';
+                                }
                             }
                             *tail++ = ',';
                             *tail++ = output_type ? output_type : auto_type;


### PR DESCRIPTION
These two commits should fix #106 and #107.

6cf5a832 limits filtering for the remote filename (introduced in 2937f54b) to cases when the filename is auto-generated from the local filename.

7a13a217 removes the 16 byte filename limit for both read and write except for the case when the remote filename is auto-generated for writing. I don't see why limiting the filename length would be needed, because as far as I can tell CBM DOS ignores extra filename characters anyway. And it hurts in the cases as discussed in #106 and #107 and even more so when working with a device which supports subdirectories, like the CMD HD.

With both commits applied, something like `cbmcopy -w -o "/subdir:fileinsubdir" 8 test.prg` works as intended, even though the filename includes a colon and is 20 characters in length, while with `cbmcopy -w 8 "test:2.prg"` the remote filename is still changed to `test 2` (`[Info] writing test:2.prg -> test 2,p,w`).