### PR TITLE
Compile fix for: grep: warning: stray \ before #

### DIFF
--- a/opencbm/LINUX/config.make
+++ b/opencbm/LINUX/config.make
@@ -2,11 +2,11 @@
 
 VERSIONH:=$(RELATIVEPATH)include/version.h
 
-OPENCBM_MAJOR   :=$(shell grep "\#define OPENCBM_VERSION_MAJOR"      ${VERSIONH}|sed -e "s/\#define OPENCBM_VERSION_[^ ]*[ ]*//")
-OPENCBM_MINOR   :=$(shell grep "\#define OPENCBM_VERSION_MINOR"      ${VERSIONH}|sed -e "s/\#define OPENCBM_VERSION_[^ ]*[ ]*//")
-OPENCBM_RELEASE :=$(shell grep "\#define OPENCBM_VERSION_SUBMINOR"   ${VERSIONH}|sed -e "s/\#define OPENCBM_VERSION_[^ ]*[ ]*//")
-OPENCBM_PATCHLVL:=$(shell grep "\#define OPENCBM_VERSION_PATCHLEVEL" ${VERSIONH}|sed -e "s/\#define OPENCBM_VERSION_[^ ]*[ ]*//")
-OPENCBM_DEVEL   :=$(shell grep "\#define OPENCBM_VERSION_DEVEL"      ${VERSIONH}|sed -e "s/\#define OPENCBM_VERSION_[^ ]*[ ]*//")
+OPENCBM_MAJOR   :=$(shell grep -F "#define OPENCBM_VERSION_MAJOR"      ${VERSIONH}|sed -e "s/\#define OPENCBM_VERSION_[^ ]*[ ]*//")
+OPENCBM_MINOR   :=$(shell grep -F "#define OPENCBM_VERSION_MINOR"      ${VERSIONH}|sed -e "s/\#define OPENCBM_VERSION_[^ ]*[ ]*//")
+OPENCBM_RELEASE :=$(shell grep -F "#define OPENCBM_VERSION_SUBMINOR"   ${VERSIONH}|sed -e "s/\#define OPENCBM_VERSION_[^ ]*[ ]*//")
+OPENCBM_PATCHLVL:=$(shell grep -F "#define OPENCBM_VERSION_PATCHLEVEL" ${VERSIONH}|sed -e "s/\#define OPENCBM_VERSION_[^ ]*[ ]*//")
+OPENCBM_DEVEL   :=$(shell grep -F "#define OPENCBM_VERSION_DEVEL"      ${VERSIONH}|sed -e "s/\#define OPENCBM_VERSION_[^ ]*[ ]*//")
 
 MAJ:=${OPENCBM_MAJOR}
 MIN:=${OPENCBM_MINOR}

--- a/xum1541/Makefile
+++ b/xum1541/Makefile
@@ -96,7 +96,7 @@ endif
 MODELVERSION= xum1541-$(MODEL)-v$(XUMFW_VERSION)
 
 # Resulting full revision number for model and firmware version
-REVISION=$(shell grep '\#define $(MODEL) ' xum1541.h | sed 's/\#define $(MODEL)//' | xargs printf "%02X")$(XUMFW_VERSION)
+REVISION=$(shell grep -F '#define $(MODEL) ' xum1541.h | sed 's/\#define $(MODEL)//' | xargs printf "%02X")$(XUMFW_VERSION)
 
 # git revision or "unknown" if either not a git repo or git command unavailable
 GITREV=$(shell git describe --always --exclude '*' || echo 'unknown')


### PR DESCRIPTION
Building OpenCBM on a modern linux (ArchlLinux) spews out 100's of the warnings below:

grep: warning: stray \ before #

This fix removes the stray '\' from grep statements and forces grep to handle the pattern as a fixed string without regexps