### PR TITLE
ZF: Fix bootloader address

### DIFF
--- a/xum1541/cpu-zoomfloppy.h
+++ b/xum1541/cpu-zoomfloppy.h
@@ -27,7 +27,7 @@ cpu_bootloader_start(void)
     // Disable timer and then jump to bootloader address
     TCCR1B = 0;
     OCR1A = 0;
-    __asm__ __volatile__ ("jmp 0x3800" "\n\t");
+    __asm__ __volatile__ ("jmp 0x7000" "\n\t");
 }
 
 // Timer and delay functions


### PR DESCRIPTION
0x3800 is the word address, but the assembler expects a byte address.