### PR TITLE
Get cbmctrl detect and cbm_identify working with DOS 1 drives

### DIFF
--- a/opencbm/lib/detect.c
+++ b/opencbm/lib/detect.c
@@ -62,6 +62,9 @@
  call this function.
 */
 
+
+#include <stdio.h>
+
 int CBMAPIDECL
 cbm_identify(CBM_FILE HandleDevice, unsigned char DeviceAddress,
              enum cbm_device_type_e *CbmDeviceType,
@@ -75,6 +78,7 @@ cbm_identify(CBM_FILE HandleDevice, unsigned char DeviceAddress,
     static char unknownDevice[] = "*unknown*, footprint=<....>";
     char *deviceString = unknownDevice;
     int rv = -1;
+    int read_magic = 0;
 
     FUNC_ENTER();
 
@@ -83,160 +87,186 @@ cbm_identify(CBM_FILE HandleDevice, unsigned char DeviceAddress,
                             HandleDevice, DeviceAddress,
                             CbmDeviceType, CbmDeviceString));
 
-    /* get footprint from 0xFF40 */
-    if (cbm_exec_command(HandleDevice, DeviceAddress, command, sizeof(command)) == 0
+    // Read two bytes at 0xFF40.  To be compatible with DOS 1 drives, we need
+    // to read a byte at a time - DOS 1 doesn't support reading 2 bytes at once
+    // We leave the command with 0x02 at the end - if we detect an appropriate
+    // device we will use that later to read 2 bytes, but for now avoid passing
+    // the last byte into exec_command
+    if (cbm_exec_command(HandleDevice, DeviceAddress, command, sizeof(command)-1) == 0
         && cbm_talk(HandleDevice, DeviceAddress, 15) == 0)
     {
-        if (cbm_raw_read(HandleDevice, buf, 3) == 3)
+        if (cbm_raw_read(HandleDevice, buf, 2) == 2)
         {
-            magic = buf[0] | (buf[1] << 8);
-
-            if(magic == 0xaaaa)
+            command[3]++; // Now read a byte at 0xFF41
+            if (cbm_exec_command(HandleDevice, DeviceAddress, command, sizeof(command)-1) == 0
+                && cbm_talk(HandleDevice, DeviceAddress, 15) == 0)
             {
-                cbm_untalk(HandleDevice);
-                command[3] = (char) 0xFE; /* get footprint from 0xFFFE, IRQ vector */
-                if (cbm_exec_command(HandleDevice, DeviceAddress, command, sizeof(command)) == 0
-                    && cbm_talk(HandleDevice, DeviceAddress, 15) == 0)
+                if (cbm_raw_read(HandleDevice, buf+1, 2) == 2)
                 {
-                    if (cbm_raw_read(HandleDevice, buf, sizeof buf) == sizeof buf
-                        && ( buf[0] != 0x67 || buf[1] != 0xFE ) )
-                    {
-                        magic = buf[0] | (buf[1] << 8);
-                    }
+                    magic = buf[0] | (buf[1] << 8);
+                    read_magic = 1;
+                    // No need to reset command[3] to what it was - it gets set
+                    // again below if required
                 }
-            }
-
-            if(magic == 0x01ba)
-            {
-                /* FD2000/4000 and 1581 must be distinguished */
-
-                cbm_untalk(HandleDevice);
-                command[3] = (char) 0x8;  /* get footprint from 0x8008 */
-                command[4] = (char) 0x80; /* get footprint from 0x8008 */
-                if (cbm_exec_command(HandleDevice, DeviceAddress, command, sizeof(command)) == 0
-                    && cbm_talk(HandleDevice, DeviceAddress, 15) == 0)
-                {
-                    if (cbm_raw_read(HandleDevice, buf, sizeof buf) == sizeof buf)
-                    {
-                        magic_extra = buf[0] | (buf[1] << 8);
-                    }
-                }
-            }
-
-            switch(magic)
-            {
-                default:
-                    unknownDevice[22] = ((magic >> 12 & 0x0F) | 0x40);
-                    unknownDevice[24] = ((magic >>  4 & 0x0F) | 0x40);
-                    magic &= 0x0F0F;
-                    magic |= 0x4040;
-                    unknownDevice[23] = magic >> 8;
-                    unknownDevice[25] = (char)magic;
-                    break;
-
-                case 0xfeb6:
-                    deviceType = cbm_dt_cbm2031;
-                    deviceString = "2031";
-                    break;
-
-                case 0xaaaa:
-                    deviceType = cbm_dt_cbm1541;
-                    deviceString = "1540 or 1541";
-                    break;
-
-                case 0xf00f:
-                    deviceType = cbm_dt_cbm1541;
-                    deviceString = "1541-II";
-                    break;
-
-                case 0xcd18:
-                    deviceType = cbm_dt_cbm1541;
-                    deviceString = "1541C";
-                    break;
-
-                case 0x10ca:
-                    deviceType = cbm_dt_cbm1541;
-                    deviceString = "DolphinDOS 1541";
-                    break;
-
-                case 0x6f10:
-                    deviceType = cbm_dt_cbm1541;
-                    deviceString = "SpeedDOS 1541";
-                    break;
-
-                case 0x2710:
-                    deviceType = cbm_dt_cbm1541;
-                    deviceString = "ProfessionalDOS 1541";
-                    break;
-
-                case 0x8085:
-                    deviceType = cbm_dt_cbm1541;
-                    deviceString = "JiffyDOS 1541";
-                    break;
-
-                case 0xaeea:
-                    deviceType = cbm_dt_cbm1541;
-                    deviceString = "64'er DOS 1541";
-                    break;
-
-                case 0x180d:
-                    deviceType = cbm_dt_cbm1541;
-                    deviceString = "Turbo Access / Turbo Trans";
-                    break;
-
-                case 0x094c:
-                    deviceType = cbm_dt_cbm1541;
-                    deviceString = "Prologic DOS";
-                    break;
-
-                case 0xfed7:
-                    deviceType = cbm_dt_cbm1570;
-                    deviceString = "1570";
-                    break;
-
-                case 0x02ac:
-                    deviceType = cbm_dt_cbm1571;
-                    deviceString = "1571";
-                    break;
-
-                case 0x01ba:
-                    switch (magic_extra) {
-                        case 0x4446: /* the "FD" in "CMD FD DOS" */
-                            deviceType = cbm_dt_fdx000;
-                            deviceString = "FD2000/FD4000";
-                            break;
-
-                        default:
-                            deviceType = cbm_dt_cbm1581;
-                            deviceString = "1581";
-                            break;
-                    }
-                    break;
-
-                case 0x32f0:
-                    deviceType = cbm_dt_cbm3040;
-                    deviceString = "3040";
-                    break;
-
-                case 0xc320:
-                case 0x20f8:
-                    deviceType = cbm_dt_cbm4040;
-                    deviceString = "4040";
-                    break;
-
-                case 0xf2e9:
-                    deviceType = cbm_dt_cbm8050;
-                    deviceString = "8050 dos2.5";
-                    break;
-
-                case 0xc866:       /* special dos2.7 ?? Speed-DOS 8250 ?? */
-                case 0xc611:
-                    deviceType = cbm_dt_cbm8250;
-                    deviceString = "8250 dos2.7";
-                    break;
-            }
-            rv = 0;
+            }   
         }
+    }
+
+    if (read_magic)
+    {
+        if(magic == 0xaaaa)
+        {
+            cbm_untalk(HandleDevice);
+            command[3] = (char) 0xFE; /* get footprint from 0xFFFE, IRQ vector */
+            if (cbm_exec_command(HandleDevice, DeviceAddress, command, sizeof(command)) == 0
+                && cbm_talk(HandleDevice, DeviceAddress, 15) == 0)
+            {
+                if (cbm_raw_read(HandleDevice, buf, sizeof buf) == sizeof buf
+                    && ( buf[0] != 0x67 || buf[1] != 0xFE ) )
+                {
+                    magic = buf[0] | (buf[1] << 8);
+                }
+            }
+        }
+
+        if(magic == 0x01ba)
+        {
+            /* FD2000/4000 and 1581 must be distinguished */
+
+            cbm_untalk(HandleDevice);
+            command[3] = (char) 0x8;  /* get footprint from 0x8008 */
+            command[4] = (char) 0x80; /* get footprint from 0x8008 */
+            if (cbm_exec_command(HandleDevice, DeviceAddress, command, sizeof(command)) == 0
+                && cbm_talk(HandleDevice, DeviceAddress, 15) == 0)
+            {
+                if (cbm_raw_read(HandleDevice, buf, sizeof buf) == sizeof buf)
+                {
+                    magic_extra = buf[0] | (buf[1] << 8);
+                }
+            }
+        }
+
+        switch(magic)
+        {
+            default:
+                unknownDevice[22] = ((magic >> 12 & 0x0F) | 0x40);
+                unknownDevice[24] = ((magic >>  4 & 0x0F) | 0x40);
+                magic &= 0x0F0F;
+                magic |= 0x4040;
+                unknownDevice[23] = magic >> 8;
+                unknownDevice[25] = (char)magic;
+                break;
+
+            case 0xfeb6:
+                deviceType = cbm_dt_cbm2031;
+                deviceString = "2031";
+                break;
+
+            case 0xaaaa:
+                deviceType = cbm_dt_cbm1541;
+                deviceString = "1540 or 1541";
+                break;
+
+            case 0xf00f:
+                deviceType = cbm_dt_cbm1541;
+                deviceString = "1541-II";
+                break;
+
+            case 0xcd18:
+                deviceType = cbm_dt_cbm1541;
+                deviceString = "1541C";
+                break;
+
+            case 0x10ca:
+                deviceType = cbm_dt_cbm1541;
+                deviceString = "DolphinDOS 1541";
+                break;
+
+            case 0x6f10:
+                deviceType = cbm_dt_cbm1541;
+                deviceString = "SpeedDOS 1541";
+                break;
+
+            case 0x2710:
+                deviceType = cbm_dt_cbm1541;
+                deviceString = "ProfessionalDOS 1541";
+                break;
+
+            case 0x8085:
+                deviceType = cbm_dt_cbm1541;
+                deviceString = "JiffyDOS 1541";
+                break;
+
+            case 0xaeea:
+                deviceType = cbm_dt_cbm1541;
+                deviceString = "64'er DOS 1541";
+                break;
+
+            case 0x180d:
+                deviceType = cbm_dt_cbm1541;
+                deviceString = "Turbo Access / Turbo Trans";
+                break;
+
+            case 0x094c:
+                deviceType = cbm_dt_cbm1541;
+                deviceString = "Prologic DOS";
+                break;
+
+            case 0xfed7:
+                deviceType = cbm_dt_cbm1570;
+                deviceString = "1570";
+                break;
+
+            case 0x02ac:
+                deviceType = cbm_dt_cbm1571;
+                deviceString = "1571";
+                break;
+
+            case 0x01ba:
+                switch (magic_extra) {
+                    case 0x4446: /* the "FD" in "CMD FD DOS" */
+                        deviceType = cbm_dt_fdx000;
+                        deviceString = "FD2000/FD4000";
+                        break;
+
+                    default:
+                        deviceType = cbm_dt_cbm1581;
+                        deviceString = "1581";
+                        break;
+                }
+                break;
+
+            case 0x20f0:
+		// A DOS 1 2040
+		// Values 0xF0 and 0x20 from ROM 901468-07
+                deviceType = cbm_dt_cbm2040;
+                deviceString = "2040";
+                break;
+
+            case 0x32f0:
+                deviceType = cbm_dt_cbm3040;
+                deviceString = "3040";
+                break;
+
+            case 0xc320:
+            case 0x20f8:
+                deviceType = cbm_dt_cbm4040;
+                deviceString = "4040";
+                break;
+
+            case 0xf2e9:
+                deviceType = cbm_dt_cbm8050;
+                deviceString = "8050 dos2.5";
+                break;
+
+            case 0xc866:       /* special dos2.7 ?? Speed-DOS 8250 ?? */
+            case 0xc611:
+                deviceType = cbm_dt_cbm8250;
+                deviceString = "8250 dos2.7";
+                break;
+        }
+        rv = 0;
+
         cbm_untalk(HandleDevice);
     }
 


### PR DESCRIPTION
This PR is for an enhancement to OpenCBM to be able to successfully identify (using cbmctrl detect) a DOS 1 2040 drive.

DOS 1 does not support retrieving multiple bytes from the M-R command simultaneously, so I have reworked the code, for both DOS 1 and DOS 2 drives to retrieve the 2 bytes at 0xFF40 sequentially.

I have tested this works with both a DOS 1 2040, and a (DOS 2) 2031, both using an IEEE-488 XUM-1541.