### PR TITLE
fix macOS compilation errors

### DIFF
--- a/opencbm/LINUX/config.make
+++ b/opencbm/LINUX/config.make
@@ -169,6 +169,7 @@ endif
 #
 ifeq "$(OS)" "Darwin"
 ETCDIR=$(PREFIX)/etc
+CFLAGS += -D_DARWIN_C_SOURCE
 
 # We therefore definitely have a libusb
 HAVE_LIBUSB0 = ${shell pkg-config libusb-legacy && echo 1} 


### PR DESCRIPTION
The main issue is that we need to define _DARWIN_C_SOURCE to have more than the base C functions defined in the headers. There are also a couple of warnings that appear on macOS, but I would suggest fixing those later.
