### PR TITLE
Fix iec_srq_write() for TEENSY2 board

### DIFF
--- a/xum1541/board-teensy2.h
+++ b/xum1541/board-teensy2.h
@@ -131,23 +131,24 @@ INLINE void
 iec_srq_write(uint8_t data)
 {
     uint8_t i;
+    uint8_t port_base_data = (DDRF & IO_ATN) | IO_SRQ;
 
     for (i = 8; i != 0; --i) {
         /*
          * Take the high bit of the data byte. Shift it down to the IO_DATA
-         * pin for the ZF board. Combine it (inverted) with the IO_SRQ line
-         * being set. Write both of these to port D at the same time.
+         * pin for the Teensy2 board. Combine it (inverted) with the IO_SRQ
+         * line being set. Write both of these to DDRF at the same time.
          *
-         * This is 7 clock cycles with gcc 9.1.0 at both -Os and -O2.
+         * IO_DATA = _BV(0) on PF0, so shift >> 7 to move bit 7 to bit 0.
          */
-        PORTD = (((data >> 4) & IO_DATA) ^ IO_DATA) | IO_SRQ;
+        DDRF = (((data >> 7) & IO_DATA) ^ IO_DATA) | port_base_data;
+
         data <<= 1;          // get next bit: 1 clock
         DELAY_US(0.3);       // (nibtools relies on this timing, do not change)
         iec_release(IO_SRQ); // release SRQ: 2 clocks
-        DELAY_US(0.935);     // (nibtools relies on this timing, do not change)
+        DELAY_US(0.80);      // (nibtools relies on this timing, do not change)
 
         // Decrement i and loop: 3 clock cycles when branch taken
-        // Total: 13 clocks per loop (minus delays); 19 clocks left.
     }
 }
 


### PR DESCRIPTION
## Summary

`iec_srq_write()` in `board-teensy2.h` was broken since commit 57bb6726, which ported the ZoomFloppy timing fix but didn't adapt the port and pin mapping for the TEENSY2 board.

The function wrote to `PORTD` with `data >> 4`, which is correct for the ZoomFloppy (IO_DATA = PD4). On the TEENSY2, IEC lines are on **Port F** and IO_DATA is `_BV(0)` on **PF0**, so the write went to the completely wrong port and bit position.

This caused `LIBUSB_ERROR_PIPE` during nibtools SRQ burst transfers, making nibble-level reads/writes impossible on TEENSY2-based xum1541 adapters. Regular sector-level transfers (d64copy etc.) were unaffected since they don't use SRQ.

## Changes

- `PORTD` → `DDRF` (correct port for TEENSY2 IEC lines)
- `data >> 4` → `data >> 7` (IO_DATA at bit 0, not bit 4)
- Preserve ATN line state via `port_base_data`, matching the PROMICRO approach
- Delay adjustment from 0.935 to 0.80 us, also matching the PROMICRO

## Test setup

- TEENSY2-based xum1541 (firmware v8), Commodore 1571 drive
- nibtools (markusC64-v637 branch) reading copy-protected disks via SRQ
- Before fix: immediate `LIBUSB_ERROR_PIPE` at "Testing communication..."
- After fix: full NIB read of 41 tracks, including tracks with intentonal read errors (copy protection), completes succesfully